### PR TITLE
feat: exit early if not a dependabot branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ jobs:
       if: github.event.ref_type == 'branch' && startsWith(github.event.ref, 'dependabot/')
       uses: actions/checkout@v1
     - name: Run dependabolt
-      if: job.steps.checkout_action.status == 'success'
       uses: malept/github-action-dependabolt@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,11 @@
 set +e
 set +x
 
+if ! echo "$GITHUB_REF" | grep -q ^refs/heads/dependabot/; then
+    echo 'Not a dependabot PR, skipping'
+    exit 0 # Exit with success because the red X looks bad
+fi
+
 if test -z "$GIT_COMMIT_EMAIL"; then
     GIT_COMMIT_EMAIL="$GITHUB_ACTOR@users.noreply.github.com"
 fi


### PR DESCRIPTION
Instead of having a conditional on the step _([which is currently broken](https://github.community/t5/GitHub-Actions/Github-Actions-Contexts-and-steps-if-conditionals-are-unusable/td-p/29621))_, check inside the action to see whether it should be running. Don't exit with a non-zero, so it doesn't show a failure in the Checks.