### PR TITLE
feat: add support for an SSH deploy key secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM debian:buster
 LABEL "repository"="https://github.com/malept/github-action-dependabolt"
 LABEL "maintainer"="Mark Lee <https://github.com/malept>"
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git npm && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git npm openssh-client && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN ssh-keyscan -t rsa github.com >> /etc/ssh/ssh_known_hosts
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ updated in a Dependabot-generated pull request.
 
 ## Secrets used
 
-This action uses `GITHUB_TOKEN` to push the commit back up to the repository.
+This action uses one of two methods to push the commit back up to the repository:
+
+* If `DEPENDABOLT_SSH_DEPLOY_KEY` is specified in the repository secrets, it is used to push the
+  commit back to the repository's SSH endpoint.
+* Otherwise, `GITHUB_TOKEN` is used to push the commit back to the repository's HTTPS endpoint. This
+  currently only works with private repositories. See the [GitHub Actions forum post](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869) for details.
 
 ## Example workflow
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,10 @@ set -e
 set -x
 
 if ! echo "$GITHUB_REF" | grep -q ^refs/heads/dependabot/; then
-    echo 'Not a dependabot PR, skipping'
-    exit 0 # Exit with success because the red X looks bad
+    if ! echo "$GITHUB_HEAD_REF" | grep -q ^dependabot/; then
+        echo 'Not a dependabot branch or PR, skipping'
+        exit 0 # Exit with success because the red X looks bad
+    fi
 fi
 
 if test -z "$INPUT_GITCOMMITEMAIL"; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,10 @@ fi
 
 packageandversion=$(git show --pretty=format: --unified=0 HEAD package.json | grep '^+ ' | sed --regexp-extended --expression 's#^\+ +"(.*)": "(.*)",?#\1@\2#g')
 
+if test -z "$packageandversion"; then
+    echo "No upgraded packages found" 1>&2
+    exit 0
+fi
 npx bolt upgrade "$packageandversion"
 
 git add .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,11 +20,21 @@ packageandversion=$(git show --pretty=format: --unified=0 HEAD package.json | gr
 
 npx bolt upgrade "$packageandversion"
 
-echo "machine github.com login $GITHUB_ACTOR password $GITHUB_TOKEN" > ~/.netrc
-chmod 600 ~/.netrc
-
 git add .
 git config user.name "$GITHUB_ACTOR"
 git config user.email "$INPUT_GITCOMMITEMAIL"
 git commit $INPUT_GITCOMMITFLAGS -m "Finish upgrading via bolt"
-git push origin HEAD:$GITHUB_REF
+
+if test -n "$DEPENDABOLT_SSH_DEPLOY_KEY"; then
+    mkdir ~/.ssh
+    echo "$DEPENDABOLT_SSH_DEPLOY_KEY" > ~/.ssh/deploy_key
+    chmod 400 ~/.ssh/deploy_key
+
+    git remote rm origin
+    git remote add origin "git@github.com:$GITHUB_REPOSITORY.git"
+else
+    echo "machine github.com login $GITHUB_ACTOR password $GITHUB_TOKEN" > ~/.netrc
+    chmod 600 ~/.netrc
+fi
+
+GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key" git push origin HEAD:$GITHUB_REF

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,14 @@ if test -z "$INPUT_GITCOMMITUSER"; then
     INPUT_GITCOMMITUSER="$GITHUB_ACTOR"
 fi
 
+if test -n "$GITHUB_HEAD_REF"; then
+    git fetch origin "$GITHUB_HEAD_REF"
+    git checkout "$GITHUB_HEAD_REF"
+    UPSTREAM_BRANCH="$GITHUB_HEAD_REF"
+else
+    UPSTREAM_BRANCH="$GITHUB_REF"
+fi
+
 packageandversion=$(git show --pretty=format: --unified=0 HEAD package.json | grep '^+ ' | sed --regexp-extended --expression 's#^\+ +"(.*)": "(.*)",?#\1@\2#g')
 
 if test -z "$packageandversion"; then
@@ -43,4 +51,4 @@ else
     chmod 600 ~/.netrc
 fi
 
-GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key" git push origin HEAD:$GITHUB_REF
+GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key" git push origin HEAD:$UPSTREAM_BRANCH


### PR DESCRIPTION
This works around the problem where [pushing a commit with `GITHUB_TOKEN` does not trigger additional GitHub Actions](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869). This issue has also been documented in the README.

Other fixes:

* Allow use with pull requests in addition to branch creation/pushes
* Exit cleanly if there aren't any packages found in the current commit