### PR TITLE
build: publish Docker images to GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,16 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Docker Image
         run: docker build -t action .
-      - name: GitHub Packages Login (Tags Only)
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: GitHub Packages Login (main/tags only)
+        if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/head/main')
         uses: azure/docker-login@v1
         with:
           login-server: docker.pkg.github.com
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push to GitHub Packages (Tags Only)
-        if: startsWith(github.ref, 'refs/tags/v')
+        - name: Push to GitHub Packages (main/tags only)
+        if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/head/main')
         run: |
-          TAG=docker.pkg.github.com/$GITHUB_REPOSITORY/action:$(echo $GITHUB_REF | sed -e 's:refs/\(head\|tag\)s/::g')
+          TAG=docker.pkg.github.com/$GITHUB_REPOSITORY/action:$(echo $GITHUB_REF | sed -e 's:refs/\(head\|tag\)s/::g' -e 's:^main$:latest:g')
           docker tag action "$TAG"
           docker push "$TAG"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - run: docker build -t action
       - name: Push to GitHub Packages
-        if: startsWith(github.ref, "refs/tags/v")
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           TAG=docker.pkg.github.com/$GITHUB_REPOSITORY/action:$(echo $GITHUB_REF | sed -e 's:refs/\(head\|tag\)s/::g')
           docker tag action "$TAG"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+*
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: docker build -t action
+      - name: Push to GitHub Packages
+        if: startsWith(github.ref, "refs/tags/v")
+        run: |
+          TAG=docker.pkg.github.com/$GITHUB_REPOSITORY/action:$(echo $GITHUB_REF | sed -e 's:refs/\(head\|tag\)s/::g')
+          docker tag action "$TAG"
+          docker push "$TAG"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - run: docker build -t action .
       - name: Push to GitHub Packages
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: docker build -t action .
-      - name: Push to GitHub Packages
+      - name: Build Docker Image
+        run: docker build -t action .
+      - name: GitHub Packages Login (Tags Only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: azure/docker-login@v1
+        with:
+          login-server: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push to GitHub Packages (Tags Only)
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           TAG=docker.pkg.github.com/$GITHUB_REPOSITORY/action:$(echo $GITHUB_REF | sed -e 's:refs/\(head\|tag\)s/::g')
           docker tag action "$TAG"
           docker push "$TAG"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,23 +8,32 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
 
+env:
+  IMAGE_NAME: action
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Build Docker Image
-        run: docker build -t action .
+        run: docker build -t $IMAGE_NAME .
       - name: GitHub Packages Login (main/tags only)
-        if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/head/main')
-        uses: azure/docker-login@v1
-        with:
-          login-server: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        - name: Push to GitHub Packages (main/tags only)
-        if: startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/head/main')
+        if: github.event_name == 'push'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      - name: Push to GitHub Packages (main/tags only)
+        if: github.event_name == 'push'
         run: |
-          TAG=docker.pkg.github.com/$GITHUB_REPOSITORY/action:$(echo $GITHUB_REF | sed -e 's:refs/\(head\|tag\)s/::g' -e 's:^main$:latest:g')
-          docker tag action "$TAG"
-          docker push "$TAG"
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - run: docker build -t action
+      - run: docker build -t action .
       - name: Push to GitHub Packages
         if: startsWith(github.ref, 'refs/tags/v')
         run: |

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ variable, which sets `-x` in the shell script.
 
 ## Docker Hub
 
-Alternatively, `uses` can be `docker://malept/gha-dependabolt:VERSION` where VERSION is `latest`
-(same as `main`) or a tagged version, minus the leading `v` (example:
-`docker://malept/gha-dependabolt:1.0.0`). This can speed up your workflow.
+Alternatively, `uses` can be `docker://docker.pkg.github.com/malept/github-action-dependabolt/action:VERSION`,
+where VERSION is `latest` (same as `main`) or a tagged version, minus the leading `v` (example:
+`docker://docker.pkg.github.com/malept/github-action-dependabolt/action:2.1.2`). This can speed up
+your workflow.


### PR DESCRIPTION
I haven't turned off the Docker Hub integration, I'm just not recommending it any more due to the recent limits.

### TODO

* [x] Restrict push builds to main branch/versioned tags only
* [x] Publish the `latest` tag from the main branch
* ~~Use the GitHub Container Registry instead of GitHub Packages (since it's deprecated :dizzy_face:)~~ _do this in a follow-up PR, sounds like it will be opt-in_
* [x] Don't run the publish steps for PRs
* [x] Update docs to mention GitHub Packages