### PR TITLE
ci: use GitHub Container Registry instead of GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  IMAGE_NAME: action
+  IMAGE_NAME: dependabolt-action
 
 jobs:
   build:
@@ -18,13 +18,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build Docker Image
         run: docker build -t $IMAGE_NAME .
-      - name: GitHub Packages Login (main/tags only)
+      - name: Registry Login (main/tags only)
         if: github.event_name == 'push'
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-      - name: Push to GitHub Packages (main/tags only)
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push to registry (main/tags only)
         if: github.event_name == 'push'
         run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           # Strip git ref prefix from version

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ variable, which sets `-x` in the shell script.
 
 ## Docker Hub
 
-Alternatively, `uses` can be `docker://docker.pkg.github.com/malept/github-action-dependabolt/action:VERSION`,
+Alternatively, `uses` can be `docker://ghcr.io/malept/dependabolt-action:VERSION`,
 where VERSION is `latest` (same as `main`) or a tagged version, minus the leading `v` (example:
-`docker://docker.pkg.github.com/malept/github-action-dependabolt/action:2.1.2`). This can speed up
-your workflow.
+`docker://ghcr.io/malept/dependabolt-action:2.1.3`). This can speed up your workflow.


### PR DESCRIPTION
There are auth issues with using the GitHub Packages Docker registry, so let's try using the GitHub Container Registry instead.