### PR TITLE
fix!: drop HTTPS write support & require SSH deploy key

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,8 @@ updated in a Dependabot-generated pull request.
 
 ## Secrets used
 
-This action uses one of two methods to push the commit back up to the repository:
-
-* If `DEPENDABOLT_SSH_DEPLOY_KEY` is specified in the repository secrets, it is used to push the
-  commit back to the repository's SSH endpoint.
-* Otherwise, `GITHUB_TOKEN` is used to push the commit back to the repository's HTTPS endpoint. This
-  currently only works with private repositories. See the [GitHub Actions forum post](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869) for details.
+This action uses an SSH deploy key with write permissions to push the commit back up to the repository.
+Specify `DEPENDABOLT_SSH_DEPLOY_KEY` in the repository secrets (the private key).
 
 ## Example workflow
 
@@ -38,7 +34,7 @@ jobs:
       with:
         gitCommitUser: Dependabolt Bot
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DEPENDABOLT_SSH_DEPLOY_KEY: ${{ secrets.DEPENDABOLT_SSH_DEPLOY_KEY }}
 ```
 
 In a production setting, `main` should be a tagged version (e.g., `v1.0.0`).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,11 @@ if ! echo "$GITHUB_REF" | grep -q ^refs/heads/dependabot/; then
     fi
 fi
 
+if test -z "$DEPENDABOLT_SSH_DEPLOY_KEY"; then
+  echo "ERROR: Please set the DEPENDABOLT_SSH_DEPLOY_KEY environment variable." 1>&2
+  exit 1
+fi
+
 if test -z "$INPUT_GITCOMMITEMAIL"; then
     INPUT_GITCOMMITEMAIL="$GITHUB_ACTOR@users.noreply.github.com"
 fi
@@ -44,17 +49,12 @@ if test -n "$(git status -s)"; then
     git config user.email "$INPUT_GITCOMMITEMAIL"
     git commit $INPUT_GITCOMMITFLAGS -m "Finish upgrading via bolt"
 
-    if test -n "$DEPENDABOLT_SSH_DEPLOY_KEY"; then
-        mkdir ~/.ssh
-        echo "$DEPENDABOLT_SSH_DEPLOY_KEY" > ~/.ssh/deploy_key
-        chmod 400 ~/.ssh/deploy_key
+      mkdir ~/.ssh
+      echo "$DEPENDABOLT_SSH_DEPLOY_KEY" > ~/.ssh/deploy_key
+      chmod 400 ~/.ssh/deploy_key
 
-        git remote rm origin
-        git remote add origin "git@github.com:$GITHUB_REPOSITORY.git"
-    else
-        echo "machine github.com login $GITHUB_ACTOR password $GITHUB_TOKEN" > ~/.netrc
-        chmod 600 ~/.netrc
-    fi
+      git remote rm origin
+      git remote add origin "git@github.com:$GITHUB_REPOSITORY.git"
 
     GIT_SSH_COMMAND="ssh -i ~/.ssh/deploy_key" git push origin HEAD:$UPSTREAM_BRANCH
 else


### PR DESCRIPTION
BREAKING CHANGE: drops support for HTTPS writes since GitHub no longer allows it in GitHub Actions. See https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/